### PR TITLE
Stop epost spam fra Github

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @navikt/teamtag

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Injiseres i [Veilarbmaofs](https://github.com/navikt/veilarbmaofs), en tjeneste 
 
 ## For Nav-ansatte
 * Dette Git-repositoriet eies av [team Inkludering i produktormåde Arbeidsgvier](https://navno.sharepoint.com/sites/intranett-prosjekter-og-utvikling/SitePages/Produktomr%C3%A5de-arbeidsgiver.aspx).
-* Slack-kanaler: [#inkludering-utvikling](https://nav-it.slack.com/archives/CQZU35J6A) eller [#arbeidsgiver-general](https://nav-it.slack.com/archives/CCM649PDH)
+* Slack-kanaler:
+  * [#inkludering-utvikling](https://nav-it.slack.com/archives/CQZU35J6A)
+  * [#arbeidsgiver-utvikling](https://nav-it.slack.com/archives/CD4MES6BB)
+  * [#arbeidsgiver-general](https://nav-it.slack.com/archives/CCM649PDH)
 
 ## For folk utenfor Nav
 * Opprett gjerne en issue i Github for alle typer spørsmål

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Injiseres i [Veilarbmaofs](https://github.com/navikt/veilarbmaofs), en tjeneste 
 
 # Henvendelser
 
-## For NAV-ansatte
+## For Nav-ansatte
 * Dette Git-repositoriet eies av team Inkludering i produktormåde Arbeidsgvier.
 * Slack-kanaler: [#inkludering-utvikling](https://nav-it.slack.com/archives/CQZU35J6A) eller [#arbeidsgiver-general](https://nav-it.slack.com/archives/CCM649PDH)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Injiseres i [Veilarbmaofs](https://github.com/navikt/veilarbmaofs), en tjeneste 
 # Henvendelser
 
 ## For Nav-ansatte
-* Dette Git-repositoriet eies av team Inkludering i produktormåde Arbeidsgvier.
+* Dette Git-repositoriet eies av [team Inkludering i produktormåde Arbeidsgvier](https://navno.sharepoint.com/sites/intranett-prosjekter-og-utvikling/SitePages/Produktomr%C3%A5de-arbeidsgiver.aspx).
 * Slack-kanaler: [#inkludering-utvikling](https://nav-it.slack.com/archives/CQZU35J6A) eller [#arbeidsgiver-general](https://nav-it.slack.com/archives/CCM649PDH)
 
 ## For folk utenfor Nav

--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 Microfrontend for å vise og endre tilretteleggingsbehov til oppfølgingsbrukere.
 
 Injiseres i [Veilarbmaofs](https://github.com/navikt/veilarbmaofs), en tjeneste for veiledere.
+
+# Henvendelser
+
+## For NAV-ansatte
+* Dette Git-repositoriet eies av team Inkludering i produktormåde Arbeidsgvier.
+* Slack-kanaler: [#inkludering-utvikling](https://nav-it.slack.com/archives/CQZU35J6A) eller [#arbeidsgiver-general](https://nav-it.slack.com/archives/CCM649PDH)
+
+## For folk utenfor Nav
+* Opprett gjerne en issue i Github for alle typer spørsmål
+* IT-utviklerne i Github-teamet https://github.com/orgs/navikt/teams/arbeidsgiver
+* IT-avdelingen i [Arbeids- og velferdsdirektoratet](https://www.nav.no/no/NAV+og+samfunn/Kontakt+NAV/Relatert+informasjon/arbeids-og-velferdsdirektoratet-kontorinformasjon)


### PR DESCRIPTION
The CODEOWNERS file makes Github generate very noisy email notifications to the team and reviewers can't tell the difference between being explicitly added as a reviewer versus by way of the teamname.